### PR TITLE
Update Python API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,40 @@ If you encounter build issues, please see the
 [Github Actions configuration](https://github.com/google-deepmind/mujoco_mpc/blob/main/.github/workflows/build.yml).
 Note, we are using `clang-14`.
 
+# Python API
+
+We provide a simple Python API for MJPC. This API is still experimental and expects some more experience from its users. For example, the correct usage requires that the model (defined in Python) and the MJPC task (i.e., the residual and transition functions defined in C++) are compatible with each other. Currently, the Python API does not provide any particular error handling for verifying this compatibilty and may be difficult to debug without more in-depth knowedge about mujoco and MJPC.
+
+- [agent.py](../python/mujoco_mpc/agent.py) for available methods for planning.
+
+- [filter.py](../python/mujoco_mpc/filter.py) for available methods for state estimation.
+
+- [direct.py](../python/mujoco_mpc/direct.py) for available methods for direct optimization.
+
+## Installing via Pip
+The MJPC Python module can be installed with:
+```sh
+pip install "${MUJOCO_MPC_ROOT}/python"
+```
+
+Alternatively:
+```sh
+python "${MUJOCO_MPC_ROOT}/python/${API}.py" install
+```
+
+Test that installation was successful:
+```sh
+python "${MUJOCO_MPC_ROOT}/python/mujoco_mpc/${API_TEST}.py"
+```
+
+where API(_TEST) can be: agent(_test), filter(_test), or direct(_test).
+
+
+## Example Usage
+See [cartpole.py](../python/mujoco_mpc/demos/agent/cartpole.py) for example usage for planning.
+
+See [cartpole_trajopt.py](../python/mujoco_mpc/demos/direct/cartpole_trajopt.py) for usage for direct optimization.
+
 ## Predictive Control
 
 See the [Predictive Control](docs/OVERVIEW.md) documentation for more

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -293,15 +293,3 @@ This includes:
 - userdata: `data->userdata`
 - time: `data->time`
 
-# Python API
-
-We provide a simple Python API for MJPC. This API is still experimental and expects some more experience from its users. For example, the correct usage requires that the model (defined in Python) and the MJPC task (i.e. the residual and transition functions defined in C++) are compatible with each other. Currently, the Python API does not provide any particular error handling for verifying this compatibilty and may be difficult to debug without more in-depth knowedge about mujoco and MJPC.
-
-## Installing via Pip
-The MJPC Python module can be installed with:
-```sh
-pip install "${MUJOCO_MPC_ROOT}/python"
-```
-
-## Example Usage
-See [agent_test.py](../python/mujoco_mpc/agent_test.py) for example usage.

--- a/python/mujoco_mpc/demos/agent/cartpole.py
+++ b/python/mujoco_mpc/demos/agent/cartpole.py
@@ -1,0 +1,171 @@
+# Copyright 2022 DeepMind Technologies Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import matplotlib.pyplot as plt
+import mediapy as media
+import mujoco
+import numpy as np
+import os
+import pathlib
+
+# set current directory: mujoco_mpc/python/mujoco_mpc
+from mujoco_mpc import agent as agent_lib
+
+# %matplotlib inline
+
+# %%
+# model
+model_path = (
+  pathlib.Path(os.path.abspath('')).parent.parent.parent
+  / "mujoco_mpc/mjpc/tasks/cartpole/task.xml"
+)
+model = mujoco.MjModel.from_xml_path(str(model_path))
+
+# data
+data = mujoco.MjData(model)
+
+# renderer
+renderer = mujoco.Renderer(model)
+
+# %%
+# agent
+agent = agent_lib.Agent(task_id="Cartpole", model=model)
+
+# weights
+agent.set_cost_weights({'Velocity': 0.15})
+print("Cost weights:", agent.get_cost_weights())
+
+# parameters
+agent.set_task_parameter("Goal", -1.0)
+print("Parameters:", agent.get_task_parameters())
+
+# %%
+# rollout horizon
+T = 1500
+
+# trajectories
+qpos = np.zeros((model.nq, T))
+qvel = np.zeros((model.nv, T))
+ctrl = np.zeros((model.nu, T - 1))
+time = np.zeros(T)
+
+# costs
+cost_total = np.zeros(T - 1)
+cost_terms = np.zeros((len(agent.get_cost_term_values()), T - 1))
+
+# rollout
+mujoco.mj_resetData(model, data)
+
+# cache initial state
+qpos[:, 0] = data.qpos
+qvel[:, 0] = data.qvel
+time[0] = data.time
+
+# frames
+frames = []
+FPS = 1.0 / model.opt.timestep
+
+# simulate
+for t in range(T - 1):
+  if (t % 100 == 0): print("t = ", t)
+
+  # set planner state
+  agent.set_state(
+        time=data.time,
+        qpos=data.qpos,
+        qvel=data.qvel,
+        act=data.act,
+        mocap_pos=data.mocap_pos,
+        mocap_quat=data.mocap_quat,
+        userdata=data.userdata,
+    )
+
+  # run planner for num_steps
+  num_steps = 10
+  for _ in range(num_steps):
+    agent.planner_step()
+
+  # get costs
+  cost_total[t] = agent.get_total_cost()
+  for (i, c) in enumerate(agent.get_cost_term_values().items()):
+    cost_terms[i, t] = c[1]
+
+  # set ctrl from agent policy
+  data.ctrl = agent.get_action()
+  ctrl[:, t] = data.ctrl
+
+  # step
+  mujoco.mj_step(model, data)
+
+  # cache
+  qpos[:, t + 1] = data.qpos
+  qvel[:, t + 1] = data.qvel
+  time[t + 1] = data.time
+
+  # render and save frames
+  renderer.update_scene(data)
+  pixels = renderer.render()
+  frames.append(pixels)
+
+# reset
+agent.reset()
+
+# display video
+SLOWDOWN = 0.5
+media.show_video(frames, fps=SLOWDOWN * FPS)
+
+# %%
+# plot position
+fig = plt.figure()
+
+plt.plot(time, qpos[0, :], label="q0", color="blue")
+plt.plot(time, qpos[1, :], label="q1", color="orange")
+
+plt.legend()
+plt.xlabel("Time (s)")
+plt.ylabel("Configuration")
+
+# %%
+# plot velocity
+fig = plt.figure()
+
+plt.plot(time, qvel[0, :], label="v0", color="blue")
+plt.plot(time, qvel[1, :], label="v1", color="orange")
+
+plt.legend()
+plt.xlabel("Time (s)")
+plt.ylabel("Velocity")
+
+# %%
+# plot control
+fig = plt.figure()
+
+plt.plot(time[:-1], ctrl[0, :], color="blue")
+
+plt.xlabel("Time (s)")
+plt.ylabel("Control")
+
+# %%
+# plot costs
+fig = plt.figure()
+
+for (i, c) in enumerate(agent.get_cost_term_values().items()):
+  plt.plot(time[:-1], cost_terms[i, :], label=c[0])
+
+plt.plot(time[:-1], cost_total, label="Total (weighted)", color="black")
+
+plt.legend()
+plt.xlabel("Time (s)")
+plt.ylabel("Costs")
+

--- a/python/mujoco_mpc/demos/agent/cartpole.py
+++ b/python/mujoco_mpc/demos/agent/cartpole.py
@@ -27,8 +27,8 @@ from mujoco_mpc import agent as agent_lib
 # %%
 # model
 model_path = (
-  pathlib.Path(os.path.abspath('')).parent.parent.parent
-  / "mujoco_mpc/mjpc/tasks/cartpole/task.xml"
+    pathlib.Path(os.path.abspath("")).parent.parent.parent
+    / "mujoco_mpc/mjpc/tasks/cartpole/task.xml"
 )
 model = mujoco.MjModel.from_xml_path(str(model_path))
 
@@ -43,7 +43,7 @@ renderer = mujoco.Renderer(model)
 agent = agent_lib.Agent(task_id="Cartpole", model=model)
 
 # weights
-agent.set_cost_weights({'Velocity': 0.15})
+agent.set_cost_weights({"Velocity": 0.15})
 print("Cost weights:", agent.get_cost_weights())
 
 # parameters
@@ -78,18 +78,19 @@ FPS = 1.0 / model.opt.timestep
 
 # simulate
 for t in range(T - 1):
-  if (t % 100 == 0): print("t = ", t)
+  if t % 100 == 0:
+    print("t = ", t)
 
   # set planner state
   agent.set_state(
-        time=data.time,
-        qpos=data.qpos,
-        qvel=data.qvel,
-        act=data.act,
-        mocap_pos=data.mocap_pos,
-        mocap_quat=data.mocap_quat,
-        userdata=data.userdata,
-    )
+      time=data.time,
+      qpos=data.qpos,
+      qvel=data.qvel,
+      act=data.act,
+      mocap_pos=data.mocap_pos,
+      mocap_quat=data.mocap_quat,
+      userdata=data.userdata,
+  )
 
   # run planner for num_steps
   num_steps = 10
@@ -98,7 +99,7 @@ for t in range(T - 1):
 
   # get costs
   cost_total[t] = agent.get_total_cost()
-  for (i, c) in enumerate(agent.get_cost_term_values().items()):
+  for i, c in enumerate(agent.get_cost_term_values().items()):
     cost_terms[i, t] = c[1]
 
   # set ctrl from agent policy
@@ -160,7 +161,7 @@ plt.ylabel("Control")
 # plot costs
 fig = plt.figure()
 
-for (i, c) in enumerate(agent.get_cost_term_values().items()):
+for i, c in enumerate(agent.get_cost_term_values().items()):
   plt.plot(time[:-1], cost_terms[i, :], label=c[0])
 
 plt.plot(time[:-1], cost_total, label="Total (weighted)", color="black")
@@ -168,4 +169,3 @@ plt.plot(time[:-1], cost_total, label="Total (weighted)", color="black")
 plt.legend()
 plt.xlabel("Time (s)")
 plt.ylabel("Costs")
-


### PR DESCRIPTION
- Move Python API docs to main README. 
- Add alternative python installation instructions.
- Add information about filter and direct APIs.
- Add cartpole python example for agent API.