### PR TITLE
Fix grpc path for direct, filter

### DIFF
--- a/python/setup_direct.py
+++ b/python/setup_direct.py
@@ -60,7 +60,7 @@ class GenerateProtoGrpcCommand(setuptools.Command):
 
     direct_proto_filename = "direct.proto"
     direct_proto_source_path = Path(
-        "..", "grpc", direct_proto_filename
+        "..", "mjpc", "grpc", direct_proto_filename
     ).resolve()
     assert self.build_lib is not None
     build_lib_path = Path(self.build_lib).resolve()

--- a/python/setup_filter.py
+++ b/python/setup_filter.py
@@ -59,7 +59,9 @@ class GenerateProtoGrpcCommand(setuptools.Command):
     from grpc_tools import protoc  # pylint: disable=import-outside-toplevel
 
     filter_proto_filename = "filter.proto"
-    filter_proto_source_path = Path("..", "grpc", filter_proto_filename).resolve()
+    filter_proto_source_path = Path(
+        "..", "mjpc", "grpc", filter_proto_filename
+    ).resolve()
     assert self.build_lib is not None
     build_lib_path = Path(self.build_lib).resolve()
     proto_module_relative_path = Path(


### PR DESCRIPTION
Should be able to install direct and filter python interfaces now. The path wasn't updated after moving the grpc directory.

@alberthli 
@erez-tom 