### PR TITLE
Disable clashing min/max macros on Windows

### DIFF
--- a/mjpc/utilities.cc
+++ b/mjpc/utilities.cc
@@ -45,6 +45,7 @@
 
 extern "C" {
 #if defined(_WIN32) || defined(__CYGWIN__)
+#define NOMINMAX
 #include <windows.h>
 #else
 #if defined(__APPLE__)


### PR DESCRIPTION
On Windows, including "Windows.h" defines min() and max() macros that clash with the STL functions under `<algorithm>`.

This causes a compilation error on Visual Studio 2022:

```
FAILED: mjpc/CMakeFiles/libmjpc.dir/utilities.cc.obj 

[...]

C:\[...]\mujoco_mpc\mjpc\utilities.cc(822): error C2589: '(': illegal token on right side of '::'
C:\[...]\mujoco_mpc\mjpc\utilities.cc(822): error C2062: type 'unknown-type' unexpected
C:\[...]\mujoco_mpc\mjpc\utilities.cc(822): error C2059: syntax error: ')'
```

Defining `NOMINMAX` before the include disables the definition of these macros, allowing the use of `std::max()` from `<algorithm>`.