### PR TITLE
Set simulation state from Python API

### DIFF
--- a/mjpc/grpc/agent.proto
+++ b/mjpc/grpc/agent.proto
@@ -89,6 +89,7 @@ message GetStateResponse {
 
 message SetStateRequest {
   State state = 1;
+  bool set_simulation = 2;
 }
 message SetStateResponse {}
 

--- a/mjpc/grpc/agent_service.cc
+++ b/mjpc/grpc/agent_service.cc
@@ -170,6 +170,17 @@ grpc::Status AgentService::SetState(grpc::ServerContext* context,
   task->Transition(model, data_);
   agent_.SetState(data_);
 
+  // Set simulation state
+  if (request->set_simulation()) {
+    Agent::StepJob job = [&agent_data = data_](
+                             Agent* agent, const mjModel* model, mjData* data) {
+      mju_copy(data->qpos, agent_data->qpos, model->nq);
+      mju_copy(data->qvel, agent_data->qvel, model->nv);
+      data->time = agent_data->time;
+    };
+    agent_.RunBeforeStep(std::move(job));
+  }
+
   return grpc::Status::OK;
 }
 

--- a/python/mujoco_mpc/agent.py
+++ b/python/mujoco_mpc/agent.py
@@ -189,6 +189,7 @@ class Agent(contextlib.AbstractContextManager):
       mocap_pos: Optional[npt.ArrayLike] = None,
       mocap_quat: Optional[npt.ArrayLike] = None,
       userdata: Optional[npt.ArrayLike] = None,
+      set_simulation: Optional[bool] = False,
   ):
     """Set `Agent`'s MuJoCo `data` state.
 
@@ -200,6 +201,7 @@ class Agent(contextlib.AbstractContextManager):
       mocap_pos: `data.mocap_pos`.
       mocap_quat: `data.mocap_quat`.
       userdata: `data.userdata`.
+      set_simulation: bool, set the simulation state.
     """
     # if mocap_pos is an ndarray rather than a list, flatten it
     if hasattr(mocap_pos, "flatten"):
@@ -217,7 +219,9 @@ class Agent(contextlib.AbstractContextManager):
         userdata=userdata if userdata is not None else [],
     )
 
-    set_state_request = agent_pb2.SetStateRequest(state=state)
+    set_state_request = agent_pb2.SetStateRequest(
+        state=state, set_simulation=set_simulation
+    )
     self.stub.SetState(set_state_request)
 
   def get_state(self) -> agent_pb2.State:


### PR DESCRIPTION
Optionally, set the simulation state (`qpos`, `qvel`, `time`) via the Python API. Useful for visualizing state estimate in GUI during hardware in-the-loop testing.