### PR TITLE
Set data->ctrl in AgentService::GetAction

### DIFF
--- a/mjpc/grpc/agent_service.cc
+++ b/mjpc/grpc/agent_service.cc
@@ -179,8 +179,15 @@ grpc::Status AgentService::GetAction(grpc::ServerContext* context,
   if (!Initialized()) {
     return {grpc::StatusCode::FAILED_PRECONDITION, "Init not called."};
   }
-  return grpc_agent_util::GetAction(
+  // get action
+  auto out = grpc_agent_util::GetAction(
       request, &agent_, model, rollout_data_.get(), &rollout_state_, response);
+  // set data
+  auto action = response->action().data();
+  for (int i = 0; i < model->nu; i++) {
+    data_->ctrl[i] = action[i];
+  }
+  return out;
 }
 
 grpc::Status AgentService::GetResiduals(

--- a/python/mujoco_mpc/demos/agent/cartpole.py
+++ b/python/mujoco_mpc/demos/agent/cartpole.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# %%
 import matplotlib.pyplot as plt
-import mediapy as media
+# import mediapy as media
 import mujoco
 import numpy as np
 import pathlib
@@ -96,14 +97,14 @@ for t in range(T - 1):
   for _ in range(num_steps):
     agent.planner_step()
 
+  # set ctrl from agent policy
+  data.ctrl = agent.get_action()
+  ctrl[:, t] = data.ctrl
+
   # get costs
   cost_total[t] = agent.get_total_cost()
   for i, c in enumerate(agent.get_cost_term_values().items()):
     cost_terms[i, t] = c[1]
-
-  # set ctrl from agent policy
-  data.ctrl = agent.get_action()
-  ctrl[:, t] = data.ctrl
 
   # step
   mujoco.mj_step(model, data)

--- a/python/mujoco_mpc/demos/agent/cartpole.py
+++ b/python/mujoco_mpc/demos/agent/cartpole.py
@@ -14,7 +14,7 @@
 
 # %%
 import matplotlib.pyplot as plt
-# import mediapy as media
+import mediapy as media
 import mujoco
 import numpy as np
 import pathlib

--- a/python/setup.py
+++ b/python/setup.py
@@ -286,6 +286,8 @@ setuptools.setup(
     install_requires=[
         "brax",
         "grpcio",
+        "matplotlib",
+        "mediapy",
         "mujoco >= 3.1.1",
         "mujoco-mjx",
         "protobuf",


### PR DESCRIPTION
Addressing #326

- Set `data->ctrl` in `AgentService::GetAction` in order to correctly compute cost terms that are dependent on `ctrl`.
- Modify demos/agent/cartpole.py example to call `agent.get_action` prior to `agent.get_total_cost`.
- Add matplotlib and mediapy to install requires in setup.py.