### PR TITLE
Fix glfw name when using system installed version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,9 +149,9 @@ findorfetch(
   USE_SYSTEM_PACKAGE
   MJPC_USE_SYSTEM_GLFW
   PACKAGE_NAME
-  glfw
+  glfw3
   LIBRARY_NAME
-  glfw
+  glfw3
   GIT_REPO
   https://github.com/glfw/glfw.git
   GIT_TAG


### PR DESCRIPTION
Fix finding the library when setting `-DMUJOCO_SIMULATE_USE_SYSTEM_GLFW=ON` to use the system glfw, similar to https://github.com/google-deepmind/mujoco/blob/088079eff0450e32b98ee743141780ed68307506/simulate/cmake/SimulateDependencies.cmake#L77-L91