### PR TITLE
Fix ReinterpretAsInt causing undefind behavior + segfaulting on release mode

### DIFF
--- a/mjpc/utilities.cc
+++ b/mjpc/utilities.cc
@@ -115,12 +115,16 @@ void Clamp(double* x, const double* bounds, int n) {
   }
 }
 
-int ReinterpretAsInt(double value) {
-  return *std::launder(reinterpret_cast<const int*>(&value));
+int64_t ReinterpretAsInt(double value) {
+  static_assert(sizeof(double) == sizeof(int64_t),
+                 "double and int64_t must have same size");
+  return std::bit_cast<int64_t>(value);
 }
 
 double ReinterpretAsDouble(int64_t value) {
-  return *std::launder(reinterpret_cast<const double*>(&value));
+  static_assert(sizeof(double) == sizeof(int64_t),
+                 "double and int64_t must have same size");
+  return std::bit_cast<double>(value);
 }
 
 absl::flat_hash_map<std::string, std::vector<std::string>>
@@ -225,7 +229,7 @@ int ParameterIndex(const mjModel* model, std::string_view name) {
 double DefaultResidualSelection(const mjModel* m, int numeric_index) {
   // list selections are stored as ints, but numeric values are doubles.
   int64_t value = m->numeric_data[m->numeric_adr[numeric_index]];
-  return *std::launder(reinterpret_cast<const double*>(&value));
+  return ReinterpretAsDouble(value);
 }
 
 int CostTermByName(const mjModel* m, const std::string& name) {

--- a/mjpc/utilities.h
+++ b/mjpc/utilities.h
@@ -66,8 +66,8 @@ T GetNumberOrDefault(T default_value, const mjModel* m, std::string_view name) {
   return GetNumber<T>(m, name).value_or(default_value);
 }
 
-// reinterpret double as int
-int ReinterpretAsInt(double value);
+// reinterpret double as int64_t
+int64_t ReinterpretAsInt(double value);
 
 // reinterpret int64_t as double
 double ReinterpretAsDouble(int64_t value);


### PR DESCRIPTION
Should fix https://github.com/google-deepmind/mujoco_mpc/issues/23.

I kept getting a segfault when building with `Release` mode (For some reason I don't get it with `RelWithDebugInfo`). I think it's because in the previous implementation using `reinterpret_cast` is causing an undefined behavior (Due to type size mismatch?)

This is a compiler-explorer link that shows the bug https://godbolt.org/z/hWW5GcGeY

@nimrod-gileadi could you please test this since you ran into the same issue?
