### PR TITLE
Fix humanoid walk cost term order

### DIFF
--- a/mjpc/tasks/humanoid/walk/task.xml
+++ b/mjpc/tasks/humanoid/walk/task.xml
@@ -30,8 +30,8 @@
     <user name="Balance" dim="2" user="1 5.0 0.0 25.0 0.02 4.0" />
     <user name="Upright" dim="8" user="2 5.0 0.0 25.0 0.01" />
     <user name="Posture" dim="21" user="0 0.025 0 1.0" />
-    <user name="Velocity" dim="2" user="7 0.625 0 25.0 0.2 4.0" />
     <user name="Walk" dim="1" user="7 1.0 0.0 25.0 0.5 3.0" />
+    <user name="Velocity" dim="2" user="7 0.625 0 25.0 0.2 4.0" />
     <user name="Control" dim="21" user="3 0.1 0 1.0 0.3" />
 
     <!-- estimator measurements -->


### PR DESCRIPTION
Fixes #359.

The Humanoid Walk residual function emits the scalar forward-speed residual before the two-dimensional feet-velocity residual, while the XML declared those cost terms in the opposite order.

This swaps the `Walk` and `Velocity` sensor declarations so the XML term dimensions, names, weights, and parameters align with the residual vector produced by `walk.cc`.

The change is intentionally limited to the XML ordering and remains a draft for CI validation.