### PR TITLE
Use pip for Python API installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ cd python
 
 Install the Python module:
 ```sh
-python setup.py install
+python -m pip install .
 ```
 
 Test that installation was successful:


### PR DESCRIPTION
Fixes #372.

Replace the deprecated `python setup.py install` instruction for the Python API with the standards-based local project installation command:

`python -m pip install .`

This avoids setuptools' deprecated direct `setup.py install` path while preserving the documented installation workflow.