### PR TITLE
Fix malformed cube patch header

### DIFF
--- a/mjpc/tasks/common_assets/cube.xml.patch
+++ b/mjpc/tasks/common_assets/cube.xml.patch
@@ -1,4 +1,4 @@
-mjpc/tasks/cube.xml.patch--- common_assets/reorientation_cube.xml	2024-02-11 18:42:07
+--- common_assets/reorientation_cube.xml	2024-02-11 18:42:07
 +++ hand/cube.xml	2024-02-12 14:52:27
 @@ -19,9 +19,9 @@
    </asset>


### PR DESCRIPTION
Fixes #355.

## Summary

`mjpc/tasks/common_assets/cube.xml.patch` currently begins with `mjpc/tasks/cube.xml.patch--- ...`, so the unified-diff `---` header is not at the start of the line. The `patch` command therefore rejects the file with `missing header for unified diff`.

This removes the accidental filename prefix so the patch is valid unified diff syntax again. No task parameters or model changes are modified.

## Validation

- Final diff: 1 file, +1/-1 line, one commit, with no unrelated changes.
- Branch is based on current upstream `main` at `ff572a21e7c2bf9fda62e1862a758da7e9a8719b`.
- Full build was not run locally in this environment; upstream CI should validate the task resource pipeline.
