### PR TITLE
Document practical Direct optimization workflow

### DIFF
--- a/docs/DIRECT.md
+++ b/docs/DIRECT.md
@@ -5,6 +5,7 @@
 - [Direct optimizer](#direct-optimizer)
   - [Cost Function](#cost-function)
   - [Cost Derivatives](#cost-derivatives)
+  - [Practical workflow](#practical-workflow)
   - [Reference](#reference)
   - [API](#api)
 
@@ -94,6 +95,56 @@ where
 - $N_{gg} = \textbf{diag}\Big(\textbf{diag}(w_g) r_{g_1}, \dots, \textbf{diag}(w_g) r_{g_t} \dots, \textbf{diag}(w_g) r_{g_{T-1}} \Big)$
 
 This approximation: 1) is computationally less expensive compared to computing the exact Hessian 2) ensures the matrix is [positive semidefinite](https://en.wikipedia.org/wiki/Gauss%E2%80%93Newton_algorithm).
+
+## Practical workflow
+
+`Direct` estimates a configuration trajectory from sensor and force measurements. The configuration trajectory is the
+optimizer's decision variable; the sensor trajectory is obtained by evaluating the MuJoCo sensor model at those
+configurations. As a result, `sensor_measurement` and `configuration` are not interchangeable arrays, even when a model
+contains joint-position sensors.
+
+A minimal workflow is demonstrated by
+[`DirectOptimize.Particle2D`](../mjpc/test/direct/direct_optimize_test.cc). The test:
+
+1. Rolls out a model to obtain a reference configuration, actuator-force and sensor trajectory.
+2. Copies the reference configuration into `configuration` and `configuration_previous` as the initial estimate.
+3. Copies the rollout's `sensordata` into `sensor_measurement` and `qfrc_actuator` into `force_measurement`.
+4. Perturbs `configuration`, then calls `Optimize()`.
+5. Checks that the cost and gradient decrease and that the recovered configuration is close to the reference rollout.
+
+The essential setup is:
+
+```cpp
+Direct optimizer(model, T);
+mju_copy(optimizer.configuration.Data(), sim.qpos.Data(), nq * T);
+mju_copy(optimizer.configuration_previous.Data(), sim.qpos.Data(), nq * T);
+mju_copy(optimizer.force_measurement.Data(), sim.qfrc_actuator.Data(), nv * T);
+mju_copy(optimizer.sensor_measurement.Data(), sim.sensor.Data(), ns * T);
+
+// Perturb optimizer.configuration here to create the initial estimation error.
+optimizer.Optimize();
+```
+
+After optimization, compare like with like:
+
+- compare `configuration` with the expected `qpos` trajectory;
+- compare `sensor_prediction` with `sensor_measurement` to inspect sensor residuals;
+- compare `force_prediction` with `force_measurement` to inspect inverse-dynamics residuals.
+
+A match between `sensor_prediction` and `sensor_measurement` only means that the estimated state reproduces the measured
+sensor values. It does not in general imply element-wise equality between `configuration` (`qpos`) and
+`sensor_measurement` (`sensordata`): sensors may have different dimensions, represent derived quantities, or observe
+only part of the configuration.
+
+There are also boundary conditions to keep in mind. At the first timestep only position-stage sensor residuals are used.
+At the last timestep, position and velocity sensor residuals are disabled by default; they can be enabled with
+`settings.last_step_position_sensors` and `settings.last_step_velocity_sensors`. Acceleration-stage sensor residuals are
+not used at either boundary because finite-difference acceleration requires neighbouring configurations.
+
+For a trajectory-tracking application, desired joint configurations should therefore not be treated as if they were
+raw sensor measurements without first checking that the model's sensor definitions and the enabled residual terms encode
+that objective. `Direct` is solving the sensor/force estimation problem defined in the [cost function](#cost-function),
+including its process and sensor weights.
 
 ## Reference
 [Physically-Consistent Sensor Fusion in Contact-Rich Behaviors](https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=31c0842aa1d4808541a64014c24928123e1d949e).


### PR DESCRIPTION
Fixes #393.

Adds a practical Direct-optimizer workflow to `docs/DIRECT.md`, based on the existing `DirectOptimize.Particle2D` regression test.

The new section explains:
- how to initialise configuration, sensor, and force trajectories;
- which arrays should be compared after optimization;
- why matching `sensor_prediction` and `sensor_measurement` does not generally imply element-wise equality with `configuration`;
- the first/last timestep sensor-residual behavior controlled by the Direct settings;
- why desired configurations should not be treated as raw sensor measurements without checking the sensor model and enabled residuals.

Validation: `git diff --check` passes. Documentation-only change; no runtime code is modified.
